### PR TITLE
ci: ignore generated files when checking conflicts

### DIFF
--- a/.github/workflows/reusables-basic.yml
+++ b/.github/workflows/reusables-basic.yml
@@ -162,9 +162,11 @@ jobs:
           # Search for conflict markers recursively in the current directory.
           # Exclude common directories like .git and node_modules.
           # The '|| true' prevents the script from exiting if grep finds no matches.
-          CONFLICT_FILES=$(grep -r -n -E '<<<<<<<|=======|>>>>>>>' \
+          CONFLICT_FILES=$(grep -r -n -E '^(<<<<<<<|=======|>>>>>>>)' \
             --exclude-dir=.git \
             --exclude-dir=node_modules \
+            --exclude-dir=dist \
+            --exclude-dir=build \
             --exclude=reusables-basic.yml \
             . 2>/dev/null || true)
 


### PR DESCRIPTION
<!-- 請先閱讀我們手冊的 [How to PR](https://hackmd.io/@sessatakuma/pr_template#How-to-PR) 章節 -->
<!-- 記得修改PR標題成 conventional commit 之標題格式  -->

### 目的
解決判斷conflicts時會誤判generated files之狀況