### PR TITLE
fix: only errors in eslint trigger failure detection

### DIFF
--- a/.github/workflows/reusables-frontend.yml
+++ b/.github/workflows/reusables-frontend.yml
@@ -198,6 +198,9 @@ jobs:
                 });
               });
             "
+          fi
+
+          if [ $ESLINT_EXIT_CODE -ne 0 ]; then
             echo "status=failure" >> $GITHUB_OUTPUT
             echo "summary=❌ **ESLint:** Issues found. Please review the annotations above." >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
<!-- 請先閱讀我們手冊的 [How to PR](https://hackmd.io/@sessatakuma/pr_template#How-to-PR) 章節 -->
<!-- 記得修改PR標題成 conventional commit 之標題格式  -->

### 目的
修改eslint的設定，使其只有在eslint有檢查到錯誤後才會回傳failure，否則則正常地回傳success。