### PR TITLE
fix: add missing checkout in frontend workflow

### DIFF
--- a/.github/workflows/reusables-frontend.yml
+++ b/.github/workflows/reusables-frontend.yml
@@ -93,6 +93,9 @@ jobs:
       eslint-summary: ${{ steps.frontend-checks.outputs.eslint-summary }}
     # yamllint enable
     steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
       - name: Run Frontend Checks
         id: frontend-checks
         uses: sessatakuma/org-workflows/.github/actions/frontend-checks@main


### PR DESCRIPTION
### 目的

Prettier 設定
jpcorrect-frontend 根目錄下有 .prettierrc。
判斷邏輯：共用的 setup-prettier.sh 會檢查 if [ ! -f ".prettierrc" ] ...。
結果：腳本會發現 .prettierrc 存在，因此輸出 Prettier config already exists, skipping creation.，並使用注入的配置。

ESLint 設定
jpcorrect-frontend 根目錄下有 eslint.config.mjs。
判斷邏輯：共用的 setup-eslint.sh 會檢查 ... && [ ! -f "eslint.config.mjs" ]。
結果：腳本會發現 eslint.config.mjs 存在，因此跳過預設注入，使用你注入的配置。

### 方法／實作說明
補上缺失的 frontend checkout
其他 workflow 都已經正常運作，只有 frontend 缺失

### 關聯 Issue
fix #41 

### 附註
- TODO：
  - [ ] 確認 frontend ci 成功運作