### PR TITLE
fix: remove trailing newline in commit types

### DIFF
--- a/.github/actions/basic-checks/action.yml
+++ b/.github/actions/basic-checks/action.yml
@@ -8,8 +8,7 @@ inputs:
   types:
     description: "Valid commit type prefixes (pipe-separated)"
     required: false
-    default: >
-      build|chore|ci|docs|feat|fix|hotfix|perf|refactor|revert|style|test
+    default: build|chore|ci|docs|feat|fix|hotfix|perf|refactor|revert|style|test
   max-length:
     description: "Maximum allowed length for PR title and commit messages"
     required: false


### PR DESCRIPTION
### 目的
修復因 YAML 解析行為導致合法的 Commit 訊息（如 `test:`）被 CI 誤判為無效前綴的問題。

### 方法／實作說明
YAML 的 `>` 區塊純量（Block scalar）運算子預設會保留結尾的換行符號，導致傳入腳本的 `types` 變數結尾變成 `test\n`。這直接破壞了 `check-commit-messages.sh` 內的正則表達式 `^($TYPES)`，使得最後一個型別無法被正確匹配。

- 主要修改：
  - `.github/actions/basic-checks/action.yml`
- 關鍵實作：
  - 將 `types` input 的預設值從 `>` 區塊純量改為單行字串，消除隱藏的結尾換行符號。

### 關聯 Issue
無

